### PR TITLE
Fixing a typo in Results.py

### DIFF
--- a/openstacknagios/rally/Results.py
+++ b/openstacknagios/rally/Results.py
@@ -19,7 +19,7 @@
 """
   Nagios/Icinga plugin to check rally results.
 
-  Takes the outpup of 'rally task results' as input on stdin.
+  Takes the output of 'rally task results' as input on stdin.
   and calculates the sum of load- and full_duration and the number
   of failed scenarios.
 


### PR DESCRIPTION
Fixing a typo in the comments. s/outpup/output