### PR TITLE
fails If host and/or binary is an empty string

### DIFF
--- a/openstacknagios/neutron/Agents.py
+++ b/openstacknagios/neutron/Agents.py
@@ -49,7 +49,14 @@ class NeutronAgents(osnag.Resource):
            self.exit_error('cannot load ' + str(e))
 
         try:
-           result=neutron.list_agents(host=self.host,binary=self.binary)
+           if self.host and self.binary:
+              result=neutron.list_agents(host=self.host,binary=self.binary)
+           elif self.binary:
+              result=neutron.list_agents(binary=self.binary)
+           elif self.host:
+              result=neutron.list_agents(host=self.host)
+           else:
+              result=neutron.list_agents()
         except Exception as e:
            self.exit_error(str(e))
 


### PR DESCRIPTION
Update the list_agents call using conditionals for what parameters are passed. This fails to find any agents in rocky if both or one are an empty string/None.